### PR TITLE
Fixes to Paged 378/379i carts

### DIFF
--- a/tipi_rpi_zero.md
+++ b/tipi_rpi_zero.md
@@ -1,18 +1,18 @@
 # How to get TIPI on Raspberry PI Zero W working with MiSter via USER Port.
-These instructions are how to modify a TIPI install to be used on a Raspberry PI Zero W with the MiSter's User Port.
+These instructions are how to adjust a TIPI install to be used on a Raspberry PI Zero W with the MiSter's User Port.
 This is NOT necessary for Raspberry PI 3 and above.
 
 - SSH to Tipi
 - Login with default username/password (tipi/tipi)
-- `cd /tipi/services/libtipi`
-- `vi tipiports.c` (or `nano tipiports.c` for the non-vi folks)
-	- Goto line 55 (`:55` in vi, `CTRL+-` in Nano)
-	- uncomment this line:
-		  `// delayMicroseconds(1L);`  
-      to look like this:  
-		   `delayMicroseconds(1L);`
+- For this to work, you must be on Tipi version 2.31.  To update to 2.31, you'll either have to do it via ssh and the command line or temporarly use a Raspberry PI 3 or above to access TIPI from the TI-99/4A (call tipi) and perform an update.
+  - For manual update via SSH :
+    - `cd /home/tipi/tipi`
+    - `git pull`
+    - `cd /home/tipi`
+- `vi tipi.config` (or `nano tipi.config` for the non-vi folks)
+  - Goto the bottom of the file (`:$` in vi)
+  - Add this line: (To add a new line at EOF in vi type `:A` then press enter)   
+      `TIPI_SIG_DELAY=100`  
 - Write/Save changes and exit (`:wq` in vi, `CTRL+X,` answer `Y` to save changes, press `Enter` on filename to keep same filename)
-- `./rebuild.sh`
-	- During build process, you'll see a bunch of warnings, it's safe to ignore them.
 - `sudo reboot`
 


### PR DESCRIPTION
The masking for determining what banks were available was not working right unless the cartridge size fell on certain boundaries.
This fixes that issue.
Also updated the Tipi instructions which closes #16.